### PR TITLE
Provide "pytz" from pypi for python 3.3 and 3.8

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -957,10 +957,9 @@
 			"issues": "https://github.com/packagecontrol/pytz/issues",
 			"releases": [
 				{
-					"base": "https://github.com/packagecontrol/pytz",
-					"platforms": ["*"],
-					"python_versions": ["3.3", "3.8"],
-					"tags": true
+					"base": "https://pypi.org/project/pytz",
+					"asset": "pytz-*-py2.py3-none-any.whl",
+					"python_versions": ["3.3", "3.8"]
 				}
 			]
 		},


### PR DESCRIPTION
The library mirrored in the packagecontrol org is rather outdated and pytz claims compatibility back until 2.4