### PR TITLE
Provide "python-docx" from pypi

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -924,14 +924,14 @@
 		},
 		{
 			"name": "python-docx",
-			"description": "Python DOCX Module",
-			"author": "WriteML",
-			"issues": "https://github.com/writeml/sublime-docx/issues",
+			"description": "Create, read, and update Microsoft Word .docx files.",
+			"author": "Python OpenXML Team",
+			"issues": "https://github.com/python-openxml/python-docx/issues",
 			"releases": [
 				{
-					"base": "https://github.com/writeml/sublime-docx",
-					"python_versions": ["3.3", "3.8"],
-					"tags": true
+					"base": "https://pypi.org/project/python-docx",
+					"asset": "python_docx-*-py3-none-any.whl",
+					"python_versions": ["3.8"]
 				}
 			]
 		},

--- a/repository.json
+++ b/repository.json
@@ -929,6 +929,11 @@
 			"issues": "https://github.com/python-openxml/python-docx/issues",
 			"releases": [
 				{
+					"base": "https://github.com/writeml/sublime-docx",
+					"python_versions": ["3.3"],
+					"tags": true
+				},
+				{
 					"base": "https://pypi.org/project/python-docx",
 					"asset": "python_docx-*-py3-none-any.whl",
 					"python_versions": ["3.8"]


### PR DESCRIPTION
This commit replaces legacy dependency repo for python-docx by pypi releases.

It drops support for python 3.3, as no *.whl file exists for v0.8.11, which is the most recent version that supports 3.3.

Can/Will add back the legacy dependency repo for python 3.3 in a follow-up commit, if needed (will discuss in PR).

See: https://github.com/packagecontrol/channel/issues/1