### PR TITLE
Add soupsieve (dependency of modern beautifulsoup4)

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1158,6 +1158,19 @@
 			]
 		},
 		{
+			"name": "soupsieve",
+			"description": "A modern CSS selector implementation for Beautiful Soup. - https://github.com/facelessuser/soupsieve",
+			"author": "facelessuser",
+			"issues": "https://github.com/facelessuser/soupsieve/issues",
+			"releases": [
+				{
+					"base": "https://pypi.org/project/soupsieve",
+					"python_versions": ["3.8"],
+					"asset": "soupsieve-*-py3-none-any.whl"
+				}
+			]
+		},
+		{
 			"name": "speg",
 			"description": "A PEG-based parser interpreter with memoization - https://github.com/avakar/speg",
 			"author": "idleberg",


### PR DESCRIPTION
The latest version to support Python 3.3 is 1.9.6 (released May 17, 2020), but since the bs4 version provided by PC itself is very old and does not require soupsieve, it probably doesn't make sense to include a version for 3.3 here. It can be added later if needed.

Closes wbond/packagecontrol.io#166