### PR TITLE
Provide "wcmatch" from pypi

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1417,8 +1417,13 @@
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-wcmatch",
-					"python_versions": ["3.3", "3.8"],
+					"python_versions": ["3.3"],
 					"tags": true
+				},
+				{
+					"base": "https://pypi.org/project/wcmatch",
+					"asset": "wcmatch-*-py3-none-any",
+					"python_versions": ["3.8"]
 				}
 			]
 		},


### PR DESCRIPTION
This commit provides wcmatch from pypi.org for python 3.8

Note, it upgrades from 1.2.1 to 8.5.1 at the time of posting.