### PR TITLE
Provide "bracex" from pypi

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -109,8 +109,13 @@
 			"releases": [
 				{
 					"base": "https://github.com/facelessuser/sublime-bracex",
-					"python_versions": ["3.3", "3.8"],
+					"python_versions": ["3.3"],
 					"tags": true
+				},
+				{
+					"base": "https://pypi.org/project/bracex",
+					"asset": "bracex-*-py3-none-any.whl",
+					"python_versions": ["3.8"]
 				}
 			]
 		},


### PR DESCRIPTION
This commit provides bracex from pypi.org for python 3.8

Note it upgrades bracex from 2.1.1 to 2.4 at the time of posting this PR.