### PR TITLE
Provide "eval-type-backport" from pypi (for pydantic)

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -402,6 +402,19 @@
 			]
 		},
 		{
+			"name": "eval-type-backport",
+			"description": "Like `typing._eval_type`, but lets older Python versions use newer typing features.",
+			"author": "alexmojaki",
+			"issues": "https://github.com/alexmojaki/eval_type_backport/issues",
+			"releases": [
+				{
+					"base": "https://pypi.org/project/eval-type-backport",
+					"asset": "eval_type_backport-*-py3-none-any.whl",
+					"python_versions": ["3.8"]
+				}
+			]
+		},
+		{
 			"name": "gateone-terminal",
 			"description": "GateOne terminal",
 			"author": "randy3k",


### PR DESCRIPTION
When using py38, `from __future__ import annotations` and native type like `list[str]` , `eval-type-backport` is required for `pydantic`. https://pypi.org/project/eval-type-backport