### PR TITLE
Provide "watchdog" for py38 from pypi

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1509,14 +1509,50 @@
 		},
 		{
 			"name": "watchdog",
-			"description": "Python library to monitor filesystem events http://packages.python.org/watchdog/",
-			"author": "vovkkk",
-			"issues": "https://github.com/vovkkk/sublime-watchdog/issues",
+			"description": "Python library and shell utilities to monitor filesystem events.",
+			"author": "gorakhargosh",
+			"issues": "https://github.com/gorakhargosh/watchdog/issues",
 			"releases": [
 				{
 					"base": "https://github.com/vovkkk/sublime-watchdog",
 					"python_versions": ["3.3"],
 					"tags": true
+				},
+				{
+					"platforms": ["windows-x32"],
+					"base": "https://pypi.org/project/watchdog",
+					"asset": "watchdog-*-py3-none-win32.whl",
+					"python_versions": ["3.8"]
+				},
+				{
+					"platforms": ["windows-x64"],
+					"base": "https://pypi.org/project/watchdog",
+					"asset": "watchdog-*-py3-none-win_amd64.whl",
+					"python_versions": ["3.8"]
+				},
+				{
+					"platforms": ["linux-x64"],
+					"base": "https://pypi.org/project/watchdog",
+					"asset": "watchdog-*-py3-none-manylinux2014_x86_64.whl",
+					"python_versions": ["3.8"]
+				},
+				{
+					"platforms": ["linux-arm64"],
+					"base": "https://pypi.org/project/watchdog",
+					"asset": "watchdog-*-py3-none-manylinux2014_aarch64.whl",
+					"python_versions": ["3.8"]
+				},
+				{
+					"platforms": ["osx-x64"],
+					"base": "https://pypi.org/project/watchdog",
+					"asset": "watchdog-*-cp38-cp38-macosx_10_9_x86_64.whl",
+					"python_versions": ["3.8"]
+				},
+				{
+					"platforms": ["osx-arm64"],
+					"base": "https://pypi.org/project/watchdog",
+					"asset": "watchdog-*-cp38-cp38-macosx_11_0_arm64.whl",
+					"python_versions": ["3.8"]
 				}
 			]
 		},


### PR DESCRIPTION
We have a 8-year-ago https://github.com/vovkkk/sublime-watchdog for py33. Luckily the latest https://pypi.org/project/watchdog still supports py38.