### PR TITLE
Provde "pyzmq" for py38 from pypi

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1180,6 +1180,48 @@
 					"platforms": ["osx-x64", "linux-x32", "linux-x64", "windows-x32", "windows-x64"],
 					"python_versions": ["3.3"],
 					"tags": true
+				},
+				{
+					"base": "https://pypi.org/project/qyzmq",
+					"asset": "qyzmq-*-cp38-cp38-macosx_*_universal2.whl",
+					"platforms": ["osx-arm64"],
+					"python_versions": ["3.8"]
+				},
+				{
+					"base": "https://pypi.org/project/qyzmq",
+					"asset": "qyzmq-*-cp38-cp38-macosx_*_x86_64.whl",
+					"platforms": ["osx-x64"],
+					"python_versions": ["3.8"]
+				},
+				{
+					"base": "https://pypi.org/project/qyzmq",
+					"asset": "qyzmq-*-cp38-cp38-manylinux_*_aarch64.whl",
+					"platforms": ["linux-arm64"],
+					"python_versions": ["3.8"]
+				},
+				{
+					"base": "https://pypi.org/project/qyzmq",
+					"asset": "qyzmq-*-cp38-cp38-manylinux_*_i686.whl",
+					"platforms": ["linux-x32"],
+					"python_versions": ["3.8"]
+				},
+				{
+					"base": "https://pypi.org/project/qyzmq",
+					"asset": "qyzmq-*-cp38-cp38-manylinux_*_x86_64.whl",
+					"platforms": ["linux-x64"],
+					"python_versions": ["3.8"]
+				},
+				{
+					"base": "https://pypi.org/project/qyzmq",
+					"asset": "qyzmq-*-cp38-cp38-win32.whl",
+					"platforms": ["windows-x32"],
+					"python_versions": ["3.8"]
+				},
+				{
+					"base": "https://pypi.org/project/qyzmq",
+					"asset": "qyzmq-*-cp38-cp38-win_amd64.whl",
+					"platforms": ["windows-x64"],
+					"python_versions": ["3.8"]
 				}
 			]
 		},


### PR DESCRIPTION
This PR provides pyzmq library from pypi for python 3.8 plugins.

required for https://github.com/sschuhmann/Helium/issues/146