### PR TITLE
Add codemp wheel to dependencies

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -279,7 +279,7 @@
 			"releases": [
 				{
 					"base": "https://pypi.org/project/codemp/",
-					"asset": "codemp-*-cp38-abi3-win_amd64.whl ",
+					"asset": "codemp-*-cp38-none-win_amd64.whl",
 					"platforms": ["windows-x64"],
 					"python_versions": ["3.8"]
 				},

--- a/repository.json
+++ b/repository.json
@@ -272,7 +272,7 @@
 			]
 		},
 		{
-			"name": "libcodemp",
+			"name": "codemp",
 			"description": "codemp - collaborative editing library",
 			"author": ["alemi", "cschen", "fraaz", "frelodev"],
 			"issues": "https://github.com/hexedtech/codemp/issues",

--- a/repository.json
+++ b/repository.json
@@ -272,6 +272,32 @@
 			]
 		},
 		{
+			"name": "libcodemp",
+			"description": "codemp - collaborative editing library",
+			"author": ["alemi", "cschen", "fraaz", "frelodev"],
+			"issues": "https://github.com/hexedtech/codemp/issues",
+			"releases": [
+				{
+					"base": "https://pypi.org/project/codemp/",
+					"asset": "codemp-*-cp38-abi3-win_amd64.whl ",
+					"platforms": ["windows-x64"],
+					"python_versions": ["3.8"]
+				},
+				{
+					"base": "https://pypi.org/project/codemp/",
+					"asset": "codemp-*-cp38-abi3-manylinux_2_34_x86_64*.whl",
+					"platforms": ["linux-x64"],
+					"python_versions": ["3.8"]
+				},
+				{
+					"base": "https://pypi.org/project/codemp/",
+					"asset": "codemp-*-cp38-abi3-macosx_11_0_arm64.whl",
+					"platforms": ["osx-arm64"],
+					"python_versions": ["3.8"]
+				}
+			]
+		},
+		{
 			"name": "coloraide",
 			"description": "A color library.",
 			"author": "facelessuser",


### PR DESCRIPTION
I am developing a plugin that needs this library, and would love to be able to just have it ready without needing to ship it with the plugin itself.