### PR TITLE
Pin "pywinpty" to v0.5.7

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1337,7 +1337,7 @@
 				},
 				{
 					"base": "https://pypi.org/project/pywinpty",
-					"asset": "pywinpty-*-cp38-*-win_amd64.whl",
+					"asset": "pywinpty-0.5.7-cp38-cp38-win_amd64.whl",
 					"platforms": ["windows-x64"],
 					"python_versions": ["3.8"]
 				}


### PR DESCRIPTION
pywinpty dropped support for python 3.8 but all current versions have important issues.

- https://github.com/andfoy/pywinpty/issues/463
- https://github.com/andfoy/pywinpty/issues/484
- https://github.com/andfoy/pywinpty/issues/483

I manually downgraded to test if Terminus works with the old version, and looks like it does.