### PR TITLE
Loose "pydantic_core" wheel files' patterns

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1080,37 +1080,37 @@
 				{
 					"platforms": ["windows-x32"],
 					"base": "https://pypi.org/project/pydantic-core",
-					"asset": "pydantic_core-*-cp38-none-win32.whl",
+					"asset": "pydantic_core-*-cp38-*-win32.whl",
 					"python_versions": ["3.8"]
 				},
 				{
 					"platforms": ["windows-x64"],
 					"base": "https://pypi.org/project/pydantic-core",
-					"asset": "pydantic_core-*-cp38-none-win_amd64.whl",
+					"asset": "pydantic_core-*-cp38-*-win_amd64.whl",
 					"python_versions": ["3.8"]
 				},
 				{
 					"platforms": ["linux-x64"],
 					"base": "https://pypi.org/project/pydantic-core",
-					"asset": "pydantic_core-*-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+					"asset": "pydantic_core-*-cp38-*-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
 					"python_versions": ["3.8"]
 				},
 				{
 					"platforms": ["linux-arm64"],
 					"base": "https://pypi.org/project/pydantic-core",
-					"asset": "pydantic_core-*-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+					"asset": "pydantic_core-*-cp38-*-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
 					"python_versions": ["3.8"]
 				},
 				{
 					"platforms": ["osx-x64"],
 					"base": "https://pypi.org/project/pydantic-core",
-					"asset": "pydantic_core-*-cp38-cp38-macosx_10_12_x86_64.whl",
+					"asset": "pydantic_core-*-cp38-*-macosx_10_12_x86_64.whl",
 					"python_versions": ["3.8"]
 				},
 				{
 					"platforms": ["osx-arm64"],
 					"base": "https://pypi.org/project/pydantic-core",
-					"asset": "pydantic_core-*-cp38-cp38-macosx_11_0_arm64.whl",
+					"asset": "pydantic_core-*-cp38-*-macosx_11_0_arm64.whl",
 					"python_versions": ["3.8"]
 				}
 			]


### PR DESCRIPTION
Wheels' naming pattern changed in v2.27.2. For Windows, it was `none` but now it's `cp38`. So I change all of them into `*`.

https://pypi.org/project/pydantic-core/2.27.2/#files