### PR TITLE
Allow shellenv to be installed in 3.8

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1684,7 +1684,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/codexns/shellenv",
-					"python_versions": ["3.3"],
+					"python_versions": ["3.3","3.8"],
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Not sure why it was only limited to 3.3 (and thus breaking some package upgrades that depend on it), I've tested it locally by installing the same old shellenv package to a 38 lib folder (via package control and custom repository.json) and importing and running all the documented commands, which seemed to work (but **Windows** only)