### PR TITLE
Fix charset-normalizer doesn't work on Mac arm64

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -272,13 +272,13 @@
 				{
 					"base": "https://pypi.org/project/charset-normalizer",
 					"asset": "charset_normalizer-*-cp38-cp38-macosx_*_x86_64.whl",
-					"platforms": ["osx-arm64"],
+					"platforms": ["osx-x64"],
 					"python_versions": ["3.8"]
 				},
 				{
 					"base": "https://pypi.org/project/charset-normalizer",
 					"asset": "charset_normalizer-*-cp38-cp38-macosx_*_universal2.whl",
-					"platforms": ["osx-x64"],
+					"platforms": ["osx-arm64"],
 					"python_versions": ["3.8"]
 				},
 				{


### PR DESCRIPTION
Before this PR, Mac arm64 will install a x86_64 wheel. This PR fixes that.

Coming from https://github.com/TerminalFi/LSP-copilot/issues/243#issuecomment-2940001000