### PR TITLE
Update orjson to deliver dedicated binary to macos

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1047,8 +1047,14 @@
 				},
 				{
 					"base": "https://pypi.org/project/orjson",
-					"asset": "orjson-*-cp${py_version}-cp${py_version}-macosx_*_universal2.whl",
-					"platforms": ["osx-arm64", "osx-x64"],
+					"asset": "orjson-*-cp${py_version}-cp${py_version}-macosx_*_x86_64.whl",
+					"platforms": ["osx-x64"],
+					"python_versions": ["3.8", "3.13", "3.14"]
+				},
+				{
+					"base": "https://pypi.org/project/orjson",
+					"asset": "orjson-*-cp${py_version}-cp${py_version}-macosx_*_arm64.whl",
+					"platforms": ["osx-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{


### PR DESCRIPTION
Seems like orjson provides dedicated binary for macos so we shouldn't need to use universal2 binary which is just extra weight.

https://pypi.org/project/orjson/3.10.15/#files appears to be the last version that supports 3.8 and it already includes dedicated arm64 binary.

Have not tested this in any way, only followed the patterns used by other libraries.