### PR TITLE
Update regex to deliver dedicated arm64 binary to macos

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -1735,7 +1735,7 @@
 				},
 				{
 					"base": "https://pypi.org/project/regex",
-					"asset": "regex-*-cp${py_version}-cp${py_version}-macosx_*_universal2.whl",
+					"asset": "regex-*-cp${py_version}-cp${py_version}-macosx_*_arm64.whl",
 					"platforms": ["osx-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},


### PR DESCRIPTION
https://pypi.org/project/regex/2024.11.6/#files appears to be the last release that supports 3.8 and it already includes dedicated arm64 binary.