### PR TITLE
Fix linux asset patterns

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -191,13 +191,13 @@
 				},
 				{
 					"base": "https://pypi.org/project/cffi",
-					"asset": "cffi-*-cp${py_version}-cp${py_version}-manylinux_*_aarch64.whl",
+					"asset": "cffi-*-cp${py_version}-cp${py_version}-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/cffi",
-					"asset": "cffi-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl",
+					"asset": "cffi-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -248,13 +248,13 @@
 			"releases": [
 				{
 					"base": "https://pypi.org/project/charset-normalizer",
-					"asset": "charset_normalizer-*-cp${py_version}-cp${py_version}-manylinux_*_aarch64.whl",
+					"asset": "charset_normalizer-*-cp${py_version}-cp${py_version}-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/charset-normalizer",
-					"asset": "charset_normalizer-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl",
+					"asset": "charset_normalizer-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -318,13 +318,13 @@
 					"base": "https://pypi.org/project/ckdl",
 					"python_versions": ["3.8", "3.13", "3.14"],
 					"platforms": ["linux-x64"],
-					"asset": "ckdl-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl"
+					"asset": "ckdl-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl"
 				},
 				{
 					"base": "https://pypi.org/project/ckdl",
 					"python_versions": ["3.8", "3.13", "3.14"],
 					"platforms": ["linux-x32"],
-					"asset": "ckdl-*-cp${py_version}-cp${py_version}-manylinux_*_i686.whl"
+					"asset": "ckdl-*-cp${py_version}-cp${py_version}-manylinux*_i686.whl"
 				}
 			]
 		},
@@ -342,7 +342,7 @@
 				},
 				{
 					"base": "https://pypi.org/project/codemp",
-					"asset": "codemp-*-cp${py_version}-abi3-manylinux_*_x86_64.whl",
+					"asset": "codemp-*-cp${py_version}-abi3-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -405,19 +405,19 @@
 				},
 				{
 					"base": "https://pypi.org/project/coverage",
-					"asset": "coverage-*-cp${py_version}-cp${py_version}-manylinux_*_aarch64.whl",
+					"asset": "coverage-*-cp${py_version}-cp${py_version}-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/coverage",
-					"asset": "coverage-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl",
+					"asset": "coverage-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/coverage",
-					"asset": "coverage-*-cp${py_version}-cp${py_version}-manylinux_*_i686.whl",
+					"asset": "coverage-*-cp${py_version}-cp${py_version}-manylinux*_i686.whl",
 					"platforms": ["linux-x32"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -793,19 +793,19 @@
 				},
 				{
 					"base": "https://pypi.org/project/lxml",
-					"asset": "lxml-*-cp${py_version}-cp${py_version}-manylinux_*_aarch64.whl",
+					"asset": "lxml-*-cp${py_version}-cp${py_version}-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/lxml",
-					"asset": "lxml-*-cp${py_version}-cp${py_version}-manylinux_*_i686.whl",
+					"asset": "lxml-*-cp${py_version}-cp${py_version}-manylinux*_i686.whl",
 					"platforms": ["linux-x32"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/lxml",
-					"asset": "lxml-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl",
+					"asset": "lxml-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -859,13 +859,13 @@
 				},
 				{
 					"base": "https://pypi.org/project/MarkupSafe",
-					"asset": "?arkup?afe-*-cp${py_version}-cp${py_version}-manylinux_*_aarch64.whl",
+					"asset": "?arkup?afe-*-cp${py_version}-cp${py_version}-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/MarkupSafe",
-					"asset": "?arkup?afe-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl",
+					"asset": "?arkup?afe-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -1035,13 +1035,13 @@
 			"releases": [
 				{
 					"base": "https://pypi.org/project/orjson",
-					"asset": "orjson-*-cp${py_version}-cp${py_version}-manylinux_*_aarch64.whl",
+					"asset": "orjson-*-cp${py_version}-cp${py_version}-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/orjson",
-					"asset": "orjson-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl",
+					"asset": "orjson-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -1165,13 +1165,13 @@
 			"releases": [
 				{
 					"base": "https://pypi.org/project/pillow",
-					"asset": "pillow-*-cp${py_version}-cp${py_version}-manylinux_*_aarch64.whl",
+					"asset": "pillow-*-cp${py_version}-cp${py_version}-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/pillow",
-					"asset": "pillow-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl",
+					"asset": "pillow-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -1241,7 +1241,7 @@
 				},
 				{
 					"base": "https://pypi.org/project/psutil",
-					"asset": "psutil-*-cp${py_version}-*-manylinux_*_x86_64.whl",
+					"asset": "psutil-*-cp${py_version}-*-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -1319,13 +1319,13 @@
 			"releases": [
 				{
 					"base": "https://pypi.org/project/pycryptodome",
-					"asset": "pycryptodome-*-cp37-abi3-manylinux_*_aarch64.whl",
+					"asset": "pycryptodome-*-cp37-abi3-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/pycryptodome",
-					"asset": "pycryptodome-*-cp37-abi3-manylinux_*_x86_64.whl",
+					"asset": "pycryptodome-*-cp37-abi3-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -1382,13 +1382,13 @@
 				},
 				{
 					"base": "https://pypi.org/project/pydantic-core",
-					"asset": "pydantic_core-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl",
+					"asset": "pydantic_core-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/pydantic-core",
-					"asset": "pydantic_core-*-cp${py_version}-cp${py_version}-manylinux_*_aarch64.whl",
+					"asset": "pydantic_core-*-cp${py_version}-cp${py_version}-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -1439,13 +1439,13 @@
 				},
 				{
 					"base": "https://pypi.org/project/pygit2",
-					"asset": "pygit2-*-cp${py_version}-cp${py_version}-manylinux_*_aarch64.whl",
+					"asset": "pygit2-*-cp${py_version}-cp${py_version}-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/pygit2",
-					"asset": "pygit2-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl",
+					"asset": "pygit2-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.14"]
 				},
@@ -1526,13 +1526,13 @@
 				},
 				{
 					"base": "https://pypi.org/project/pysimdjson",
-					"asset": "pysimdjson-*-cp${py_version}-cp${py_version}-manylinux_*_aarch64.whl",
+					"asset": "pysimdjson-*-cp${py_version}-cp${py_version}-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/pysimdjson",
-					"asset": "pysimdjson-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl",
+					"asset": "pysimdjson-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -1692,19 +1692,19 @@
 				},
 				{
 					"base": "https://pypi.org/project/pyzmq",
-					"asset": "pyzmq-*-cp${py_version}-cp${py_version}-manylinux_*_aarch64.whl",
+					"asset": "pyzmq-*-cp${py_version}-cp${py_version}-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/pyzmq",
-					"asset": "pyzmq-*-cp${py_version}-cp${py_version}-manylinux_*_i686.whl",
+					"asset": "pyzmq-*-cp${py_version}-cp${py_version}-manylinux*_i686.whl",
 					"platforms": ["linux-x32"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/pyzmq",
-					"asset": "pyzmq-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl",
+					"asset": "pyzmq-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -1747,19 +1747,19 @@
 				},
 				{
 					"base": "https://pypi.org/project/regex",
-					"asset": "regex-*-cp${py_version}-cp${py_version}-manylinux_*_aarch64.whl",
+					"asset": "regex-*-cp${py_version}-cp${py_version}-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/regex",
-					"asset": "regex-*-cp${py_version}-cp${py_version}-manylinux_*_i686.whl",
+					"asset": "regex-*-cp${py_version}-cp${py_version}-manylinux*_i686.whl",
 					"platforms": ["linux-x32"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/regex",
-					"asset": "regex-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl",
+					"asset": "regex-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -1864,13 +1864,13 @@
 				},
 				{
 					"base": "https://pypi.org/project/ruamel.yaml.clib",
-					"asset": "ruamel.yaml.clib-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl",
+					"asset": "ruamel.yaml.clib-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/ruamel.yaml.clib",
-					"asset": "ruamel.yaml.clib-*-cp${py_version}-cp${py_version}-manylinux_*_aarch64.whl",
+					"asset": "ruamel.yaml.clib-*-cp${py_version}-cp${py_version}-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -2100,13 +2100,13 @@
 				},
 				{
 					"base": "https://pypi.org/project/tiktoken",
-					"asset": "tiktoken-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl",
+					"asset": "tiktoken-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/tiktoken",
-					"asset": "tiktoken-*-cp${py_version}-cp${py_version}-manylinux_*_aarch64.whl",
+					"asset": "tiktoken-*-cp${py_version}-cp${py_version}-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -2177,19 +2177,19 @@
 				},
 				{
 					"base": "https://pypi.org/project/tornado",
-					"asset": "tornado-*-cp${py_version}-*-manylinux_*_aarch64.whl",
+					"asset": "tornado-*-cp${py_version}-*-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/tornado",
-					"asset": "tornado-*-cp${py_version}-*-manylinux_*_i686.whl",
+					"asset": "tornado-*-cp${py_version}-*-manylinux*_i686.whl",
 					"platforms": ["linux-x32"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/tornado",
-					"asset": "tornado-*-cp${py_version}-*-manylinux_*_x86_64.whl",
+					"asset": "tornado-*-cp${py_version}-*-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -2215,13 +2215,13 @@
 			"releases": [
 				{
 					"base": "https://pypi.org/project/tree_sitter",
-					"asset": "tree_sitter-*-cp${py_version}-cp${py_version}-manylinux_*_aarch64.whl",
+					"asset": "tree_sitter-*-cp${py_version}-cp${py_version}-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/tree_sitter",
-					"asset": "tree_sitter-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl",
+					"asset": "tree_sitter-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -2259,13 +2259,13 @@
 			"releases": [
 				{
 					"base": "https://pypi.org/project/tree_sitter_languages",
-					"asset": "tree_sitter_languages-*-cp${py_version}-cp${py_version}-manylinux_*_aarch64.whl",
+					"asset": "tree_sitter_languages-*-cp${py_version}-cp${py_version}-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/tree_sitter_languages",
-					"asset": "tree_sitter_languages-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl",
+					"asset": "tree_sitter_languages-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
@@ -2472,13 +2472,13 @@
 				},
 				{
 					"base": "https://pypi.org/project/websockets",
-					"asset": "websockets-*-cp${py_version}-cp${py_version}-manylinux_*_x86_64.whl",
+					"asset": "websockets-*-cp${py_version}-cp${py_version}-manylinux*_x86_64.whl",
 					"platforms": ["linux-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{
 					"base": "https://pypi.org/project/websockets",
-					"asset": "websockets-*-cp${py_version}-cp${py_version}-manylinux_*_aarch64.whl",
+					"asset": "websockets-*-cp${py_version}-cp${py_version}-manylinux*_aarch64.whl",
 					"platforms": ["linux-arm64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},


### PR DESCRIPTION
Some download assets may be of form `name-cp314-cp314-manylinux2024...`, thus do not expect underscore after `manylinux`.