### PR TITLE
Use 313 version of watchdog on mac 314

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -2399,13 +2399,25 @@
 					"base": "https://pypi.org/project/watchdog",
 					"asset": "watchdog-*-cp${py_version}-cp${py_version}-macosx_*_x86_64.whl",
 					"platforms": ["osx-x64"],
-					"python_versions": ["3.8", "3.13", "3.14"]
+					"python_versions": ["3.8", "3.13"]
 				},
 				{
 					"base": "https://pypi.org/project/watchdog",
 					"asset": "watchdog-*-cp${py_version}-cp${py_version}-macosx_*_arm64.whl",
 					"platforms": ["osx-arm64"],
-					"python_versions": ["3.8", "3.13", "3.14"]
+					"python_versions": ["3.8", "3.13"]
+				},
+				{
+					"base": "https://pypi.org/project/watchdog",
+					"asset": "watchdog-*-cp313-cp313-macosx_*_x86_64.whl",
+					"platforms": ["osx-x64"],
+					"python_versions": ["3.14"]
+				},
+				{
+					"base": "https://pypi.org/project/watchdog",
+					"asset": "watchdog-*-cp313-cp313-macosx_*_arm64.whl",
+					"platforms": ["osx-arm64"],
+					"python_versions": ["3.14"]
 				}
 			]
 		},


### PR DESCRIPTION
I don't know how safe this is but 313 version seems to work in python 314 host when I try it in standalone python.

It would fix LSP-copilot which currently doesn't work on mac due to this dependency not being available. It's available on Linux and Windows because files are not as strictly versioned there.