### PR TITLE
Fix MacOS releases for charset-normalizer

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -286,14 +286,8 @@
 				},
 				{
 					"base": "https://pypi.org/project/charset-normalizer",
-					"asset": "charset_normalizer-*-cp${py_version}-cp${py_version}-macosx_*_x86_64.whl",
-					"platforms": ["osx-x64"],
-					"python_versions": ["3.8", "3.13", "3.14"]
-				},
-				{
-					"base": "https://pypi.org/project/charset-normalizer",
 					"asset": "charset_normalizer-*-cp${py_version}-cp${py_version}-macosx_*_universal2.whl",
-					"platforms": ["osx-arm64"],
+					"platforms": ["osx-arm64", "osx-x64"],
 					"python_versions": ["3.8", "3.13", "3.14"]
 				},
 				{


### PR DESCRIPTION
This commit registers universal2 releases for MacOS as only those are available for all supported python versions. Latest releases dropped explicit x86_64.