### PR TITLE
allow shellenv to be installed in 3.14

### DIFF
--- a/repository.json
+++ b/repository.json
@@ -2166,7 +2166,7 @@
 			"releases": [
 				{
 					"base": "https://github.com/codexns/shellenv",
-					"python_versions": ["3.3","3.8"],
+					"python_versions": ["3.3","3.8","3.14"],
 					"tags": true
 				}
 			]


### PR DESCRIPTION
Same as  https://github.com/packagecontrol/channel/pull/37, only tested locally on Windows just to suppress the error messages, packages seem to continue working
